### PR TITLE
solvers_off_on_initial_refinement is now declared in the .h file

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -418,6 +418,7 @@ namespace aspect
     unsigned int                   min_grid_level;
     std::vector<double>            additional_refinement_times;
     unsigned int                   adaptive_refinement_interval;
+    bool                           solvers_off_on_initial_refinement;
     bool                           run_postprocessors_on_initial_refinement;
     bool                           run_postprocessors_on_nonlinear_iterations;
     /**

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -642,7 +642,7 @@ namespace aspect
                          "Whether or not the postprocessors should be executed after "
                          "each of the initial adaptive refinement cycles that are run at "
                          "the start of the simulation.");
-      prm.declare_entry ("Solvers off during initial refinement", "false",
+      prm.declare_entry ("Solvers off on initial refinement", "false",
                          Patterns::Bool (),
                          "Whether or not solvers should be executed after the initial "
                          "adaptive refinement cycles that are run at the start of the "
@@ -1130,6 +1130,7 @@ namespace aspect
         for (unsigned int i=0; i<additional_refinement_times.size(); ++i)
           additional_refinement_times[i] *= year_in_seconds;
 
+      solvers_off_on_initial_refinement = prm.get_bool("Solvers off on initial refinement");
       run_postprocessors_on_initial_refinement = prm.get_bool("Run postprocessors on initial refinement");
     }
     prm.leave_subsection ();


### PR DESCRIPTION
The new parameter 'solvers_off_on_initial_refinement' is now declared in the parameters.h.
I changed the word 'during' for 'on' because there was already another parameter using '...on_initial_refinement'